### PR TITLE
Enable command line build to succeed on 10.8

### DIFF
--- a/filepath.xcodeproj/project.pbxproj
+++ b/filepath.xcodeproj/project.pbxproj
@@ -197,12 +197,10 @@
 				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
 			};
 			name = Debug;
 		};
@@ -214,7 +212,6 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				PREBINDING = NO;
-				SDKROOT = macosx10.6;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Hi Chendo,

In order to permit building via [Homebrew formula](https://github.com/wezm/homebrew/commit/ce19ceba075e0c0ee1e2e0bf9485347494d12161) I needed to change the Base SDK in the Xcode project. Its now `Current OS X`.

Wes
